### PR TITLE
Fix dynamic routes in starter and example apps

### DIFF
--- a/tht/sites/exampleApp/code/pages/examples/routeColors.tht
+++ b/tht/sites/exampleApp/code/pages/examples/routeColors.tht
@@ -40,7 +40,7 @@ tm linksHtml {
 
     <.panel style="margin-top: 8rem">
         <p> This page uses a route defined in <code>config/app.jcon</code> as:
-        <pre> /examples/colors-route/{color}: examples/colorsRoute.tht
+        <pre> /examples/colors-route/{color}: examples/routeColors.tht
         <small> Note: The word "route" doesn't need to be in the name.
     </>
 }

--- a/tht/sites/exampleApp/config/app.jcon
+++ b/tht/sites/exampleApp/config/app.jcon
@@ -11,7 +11,7 @@
     //---------------------------------------------------
 
     routes: {
-        /examples/colors-route/{color}: examples/colorsRoute.tht
+        /examples/colors-route/{color}: examples/routeColors.tht
     }
 
 


### PR DESCRIPTION
I suppose you want to demonstrate the dynamic route. 

To reproduce after a clean install try to access the `examples/colors-route/{color}` route and click on the buttons